### PR TITLE
Patch for MixinMinecraft.java

### DIFF
--- a/src/main/java/dhj/ingameime/mixins/MixinMinecraft.java
+++ b/src/main/java/dhj/ingameime/mixins/MixinMinecraft.java
@@ -4,6 +4,8 @@ import dhj.ingameime.ClientProxy;
 import dhj.ingameime.Internal;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
 public class MixinMinecraft {
+    private static final Logger log = LogManager.getLogger(MixinMinecraft.class);
+
     @Inject(method = "toggleFullscreen", at = @At(value = "HEAD"))
     void preToggleFullscreen(CallbackInfo ci) {
         Internal.destroyInputCtx();
@@ -21,17 +25,26 @@ public class MixinMinecraft {
         Internal.createInputCtx();
     }
 
-    @Inject(method = "displayGuiScreen", at = @At(value = "RETURN"))
-    void postDisplayScreen(GuiScreen guiScreenIn, CallbackInfo ci) {
-        // Reset pos when screen changes
-        ClientProxy.Screen.setCaretPos(0, 0);
-        // Disable input method when not screen
-        GuiScreen currentScreen = Minecraft.getMinecraft().currentScreen;
-        if (currentScreen == null)
-            ClientProxy.INSTANCE.onScreenClose();
-        else
-            ClientProxy.INSTANCE.onScreenOpen(currentScreen);
+    @Inject(method = "displayGuiScreen", at = @At("RETURN"))
+    private void postDisplayScreen(GuiScreen guiScreenIn, CallbackInfo ci) {
+        try {
+            // 如果还没初始化好 Screen proxy，就跳过
+            if (ClientProxy.Screen == null) {
+                return;
+            }
+
+            // 重置光标
+            ClientProxy.Screen.setCaretPos(0, 0);
+
+            // guiScreenIn 为 null 则说明刚关闭所有界面
+            if (guiScreenIn == null) {
+                ClientProxy.INSTANCE.onScreenClose();
+            } else {
+                ClientProxy.INSTANCE.onScreenOpen(guiScreenIn);
+            }
+        }catch (Exception e) {
+            log.error(e.getMessage());
+        }
     }
 }
-
 


### PR DESCRIPTION
Closes #1 
原始异常
```log
[21:25:40] [Client thread/ERROR] [minecraft/Minecraft]: An uncaught exception occured while displaying the init error screen, making normal report instead
java.lang.NullPointerException: null
	at net.minecraft.client.Minecraft.handler$zea000$ingameime$postDisplayScreen(MinecraftMixin.java:3852) ~[bib.class:?]
	at net.minecraft.client.Minecraft.displayGuiScreen(MinecraftMixin.java:1026) ~[bib.class:?]
	at net.minecraft.client.Minecraft.runGUILoop(MinecraftMixin.java:4878) ~[bib.class:?]
	at net.minecraft.client.Minecraft.displayInitErrorScreen(MinecraftMixin.java:4848) [bib.class:?]
	at net.minecraft.client.Minecraft.run(MinecraftMixin.java:4604) [bib.class:?]
	at net.minecraft.client.main.Main.main(SourceFile:123) [Main.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_301]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_301]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_301]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_301]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) [NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) [NewLaunch.jar:?]
[21:25:40] [Client thread/FATAL] [LoliASM]: Minecraft ran into a problem! Report saved to: C:\Users\qwe17\AppData\Roaming\PrismLauncher\instances\RevBackport\.minecraft\crash-reports\crash-2025-06-10_21.25.39-client.txt
---- Minecraft Crash Report ----
// Lolis deobfuscated this stacktrace using MCP's stable-39 mappings.
// Why did you do that?

Time: 2025-06-10 21:25:40 CST
Description: Initializing game

java.lang.NullPointerException: Initializing game
    at net.minecraft.client.Minecraft.handler$zea000$ingameime$postDisplayScreen(MinecraftMixin.java:3852)
    at net.minecraft.client.Minecraft.displayGuiScreen(MinecraftMixin.java:1026)
    at net.minecraft.client.Minecraft.init(MinecraftMixin.java:545)
    at net.minecraft.client.Minecraft.run(MinecraftMixin.java:4601)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
    at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
    at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
    at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)

No Mixin Metadata is found in the Stacktrace.

```
临时补丁(MixinMinecraft.java)
目前靠大try解决的崩溃问题 只判空不行 暂时不知道原因
倒是打了补丁之后用着似乎没什么问题
```java
    @Inject(method = "displayGuiScreen", at = @At("RETURN"))
    private void postDisplayScreen(GuiScreen guiScreenIn, CallbackInfo ci) {
        try {
            // 如果还没初始化好 Screen proxy，就跳过
            if (ClientProxy.Screen == null) {
                return;
            }

            // 重置光标
            ClientProxy.Screen.setCaretPos(0, 0);

            // guiScreenIn 为 null 则说明刚关闭所有界面
            if (guiScreenIn == null) {
                ClientProxy.INSTANCE.onScreenClose();
            } else {
                ClientProxy.INSTANCE.onScreenOpen(guiScreenIn);
            }
        }catch (Exception e) {
            log.error(e.getMessage());
        }
    }
```